### PR TITLE
feat: add support for custom language models

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A TypeScript translation of the original Python LangExtract library by Google LL
 ## Features
 
 - **Structured Information Extraction**: Extract entities, relationships, and structured data from text
-- **Multiple LLM Support**: Works with Google Gemini, OpenAI, Ollama, and other LLM providers
+- **Multiple LLM Support**: Works with Google Gemini, OpenAI, Ollama, and custom language model implementations
 - **Schema Generation**: Automatically generates JSON schemas from examples for better extraction
 - **Text Alignment**: Aligns extracted information with original text positions
 - **Interactive Visualization**: Built-in HTML visualization with animations and controls
@@ -141,6 +141,37 @@ The main function for extracting structured information from text.
 - `baseURL`: `string` - Custom base URL (for OpenAI)
 - `extractionPasses`: `number` - Number of extraction passes (default: 1)
 - `maxTokens`: `number` - Maximum tokens in the response (default: 2048)
+- `languageModel`: `BaseLanguageModel` - Custom language model implementation (optional)
+
+### Custom Language Models
+
+You can provide your own language model implementation by implementing the `BaseLanguageModel` interface:
+
+```typescript
+import { extract, BaseLanguageModel, InferenceOptions, ScoredOutput } from "langextract";
+
+class MyCustomModel implements BaseLanguageModel {
+  async infer(batchPrompts: string[], options?: InferenceOptions): Promise<ScoredOutput[][]> {
+    const results: ScoredOutput[][] = [];
+    
+    for (const prompt of batchPrompts) {
+      // Your custom inference logic here
+      const response = await myModelCall(prompt, options);
+      results.push([{ score: 1.0, output: response }]);
+    }
+    
+    return results;
+  }
+}
+
+// Use with LangExtract
+const customModel = new MyCustomModel();
+const result = await extract("Text to analyze", {
+  languageModel: customModel,  // Pass your custom model
+  examples: [/* your examples */],
+  // Note: apiKey is not required when using a custom model
+});
+```
 
 ### Core Types
 

--- a/examples/custom-model-example.ts
+++ b/examples/custom-model-example.ts
@@ -1,0 +1,210 @@
+/**
+ * Example demonstrating how to use a custom language model implementation with LangExtract.
+ * 
+ * This example shows how to create a custom language model that implements the BaseLanguageModel interface
+ * and use it with the extract function.
+ */
+
+import { extract, BaseLanguageModel, InferenceOptions, ScoredOutput, ExampleData } from "../src/index";
+
+/**
+ * Example custom language model implementation.
+ * This is a simple mock implementation for demonstration purposes.
+ * In a real-world scenario, you would implement your own inference logic
+ * that calls your actual language model service.
+ */
+class CustomLanguageModel implements BaseLanguageModel {
+  private modelName: string;
+  private customConfig: any;
+
+  constructor(config: { modelName?: string; [key: string]: any } = {}) {
+    this.modelName = config.modelName || "my-custom-model";
+    this.customConfig = config;
+  }
+
+  async infer(batchPrompts: string[], options: InferenceOptions = {}): Promise<ScoredOutput[][]> {
+    console.log(`Custom model ${this.modelName} processing ${batchPrompts.length} prompts`);
+    
+    const results: ScoredOutput[][] = [];
+
+    for (const prompt of batchPrompts) {
+      try {
+        // Simulate processing time
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // This is where you would implement your actual model inference
+        // For example, calling your custom API, local model, or other service
+        const response = await this.customInference(prompt, options);
+
+        results.push([{
+          score: 1.0,
+          output: response
+        }]);
+      } catch (error) {
+        console.error("Error in custom model inference:", error);
+        results.push([{
+          score: 0.0,
+          output: undefined
+        }]);
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Your custom inference implementation would go here.
+   * This is just a mock implementation that returns a structured JSON response.
+   */
+  private async customInference(prompt: string, options: InferenceOptions): Promise<string> {
+    // Mock response - in reality, you would call your model here
+    // The response should be in JSON format matching the expected extraction format
+    
+    // Simple pattern matching for demonstration
+    if (prompt.toLowerCase().includes("person") || prompt.toLowerCase().includes("name")) {
+      return JSON.stringify({
+        extractions: [
+          {
+            extractionClass: "person",
+            extractionText: "John Doe",
+            description: "A person mentioned in the text"
+          }
+        ]
+      });
+    } else if (prompt.toLowerCase().includes("date") || prompt.toLowerCase().includes("time")) {
+      return JSON.stringify({
+        extractions: [
+          {
+            extractionClass: "date",
+            extractionText: "2024-01-15",
+            description: "A date mentioned in the text"
+          }
+        ]
+      });
+    } else {
+      return JSON.stringify({
+        extractions: []
+      });
+    }
+  }
+}
+
+/**
+ * Example usage of custom language model with LangExtract
+ */
+async function demonstrateCustomModel() {
+  console.log("🚀 Starting custom language model demonstration...\n");
+
+  // Create your custom language model instance
+  const customModel = new CustomLanguageModel({
+    modelName: "demo-custom-model",
+    customParameter: "example-value"
+  });
+
+  // Define examples to guide the extraction
+  const examples: ExampleData[] = [
+    {
+      text: "John Smith visited the office on January 15th, 2024.",
+      extractions: [
+        {
+          extractionClass: "person",
+          extractionText: "John Smith"
+        },
+        {
+          extractionClass: "date", 
+          extractionText: "January 15th, 2024"
+        }
+      ]
+    }
+  ];
+
+  // Text to extract information from
+  const textToAnalyze = "Sarah Johnson met with the team on March 3rd, 2024 to discuss the project timeline.";
+
+  try {
+    console.log("📝 Analyzing text:", textToAnalyze);
+    console.log("\n🔍 Using custom language model for extraction...\n");
+
+    // Use the custom model with LangExtract
+    const result = await extract(textToAnalyze, {
+      languageModel: customModel,  // 👈 Pass your custom model here
+      promptDescription: "Extract people and dates from the text",
+      examples: examples,
+      formatType: "json" as any,
+      debug: true
+    });
+
+    console.log("✅ Extraction completed!");
+    console.log("\n📊 Results:");
+    console.log(JSON.stringify(result, null, 2));
+
+  } catch (error) {
+    console.error("❌ Error during extraction:", error);
+  }
+}
+
+/**
+ * Example showing how to integrate with a real language model service
+ */
+class ExternalAPILanguageModel implements BaseLanguageModel {
+  private apiKey: string;
+  private baseUrl: string;
+
+  constructor(config: { apiKey: string; baseUrl: string }) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = config.baseUrl;
+  }
+
+  async infer(batchPrompts: string[], options: InferenceOptions = {}): Promise<ScoredOutput[][]> {
+    // Example integration with external API
+    // Replace this with your actual API integration
+    
+    const results: ScoredOutput[][] = [];
+
+    for (const prompt of batchPrompts) {
+      try {
+        // Example API call structure
+        const response = await fetch(`${this.baseUrl}/v1/completions`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            prompt: prompt,
+            max_tokens: options.maxDecodeSteps || 1000,
+            temperature: options.temperature || 0.7
+          })
+        });
+
+        if (!response.ok) {
+          throw new Error(`API request failed: ${response.statusText}`);
+        }
+
+        const data = await response.json();
+        const output = data.choices?.[0]?.text || data.response || "";
+
+        results.push([{
+          score: 1.0,
+          output: output
+        }]);
+
+      } catch (error) {
+        console.error("API call failed:", error);
+        results.push([{
+          score: 0.0,
+          output: undefined
+        }]);
+      }
+    }
+
+    return results;
+  }
+}
+
+// Run the demonstration
+if (require.main === module) {
+  demonstrateCustomModel().catch(console.error);
+}
+
+export { CustomLanguageModel, ExternalAPILanguageModel };

--- a/src/__tests__/custom-model.test.ts
+++ b/src/__tests__/custom-model.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for custom language model functionality
+ */
+
+import { extract, BaseLanguageModel, InferenceOptions, ScoredOutput, ExampleData } from "../index";
+
+// Mock custom language model for testing
+class MockCustomLanguageModel implements BaseLanguageModel {
+  private responses: string[];
+  private callCount: number = 0;
+
+  constructor(responses: string[] = []) {
+    this.responses = responses;
+  }
+
+  async infer(batchPrompts: string[], options?: InferenceOptions): Promise<ScoredOutput[][]> {
+    const results: ScoredOutput[][] = [];
+
+    for (const prompt of batchPrompts) {
+      // Use the options for potential temperature or other parameters
+      const temperature = options?.temperature || 0.0;
+      
+      // Use the prompt in the response or for logging
+      const response = this.responses[this.callCount] || JSON.stringify({
+        extractions: [
+          {
+            extractionClass: "test",
+            extractionText: `mock response for prompt: ${prompt.substring(0, 20)}...`,
+            attributes: {
+              temperature: temperature.toString()
+            }
+          }
+        ]
+      });
+      
+      results.push([{
+        score: 1.0,
+        output: response
+      }]);
+      
+      this.callCount++;
+    }
+
+    return results;
+  }
+
+  getCallCount(): number {
+    return this.callCount;
+  }
+}
+
+describe("Custom Language Model Integration", () => {
+  const mockExamples: ExampleData[] = [
+    {
+      text: "John Smith visited the office.",
+      extractions: [
+        {
+          extractionClass: "person",
+          extractionText: "John Smith"
+        }
+      ]
+    }
+  ];
+
+  it("should accept a custom language model", async () => {
+    const customModel = new MockCustomLanguageModel([
+      JSON.stringify({
+        extractions: [
+          {
+            extractionClass: "person",
+            extractionText: "Custom Person"
+          }
+        ]
+      })
+    ]);
+
+    const result = await extract("Test text", {
+      languageModel: customModel,
+      examples: mockExamples,
+      promptDescription: "Extract people"
+    });
+
+    expect(result).toBeDefined();
+    expect(customModel.getCallCount()).toBeGreaterThan(0);
+  });
+
+  it("should not require apiKey when using custom model", async () => {
+    const customModel = new MockCustomLanguageModel();
+
+    // This should not throw an error about missing API key
+    await expect(extract("Test text", {
+      languageModel: customModel,
+      examples: mockExamples
+    })).resolves.toBeDefined();
+  });
+
+  it("should still require apiKey when not using custom model", async () => {
+    await expect(extract("Test text", {
+      modelType: "gemini",
+      examples: mockExamples
+    })).rejects.toThrow("API key must be provided");
+  });
+
+  it("should pass options to custom model infer method", async () => {
+    const customModel = new MockCustomLanguageModel();
+    const originalInfer = customModel.infer;
+    const mockInfer = jest.fn().mockImplementation(originalInfer.bind(customModel));
+    customModel.infer = mockInfer;
+
+    await extract("Test text", {
+      languageModel: customModel,
+      examples: mockExamples,
+      temperature: 0.8,
+      maxTokens: 1024
+    });
+
+    expect(mockInfer).toHaveBeenCalled();
+    const [, options] = mockInfer.mock.calls[0];
+    expect(options).toEqual({
+      maxDecodeSteps: 1024
+    });
+  });
+
+  it("should handle custom model errors gracefully", async () => {
+    class ErrorModel implements BaseLanguageModel {
+      async infer(): Promise<ScoredOutput[][]> {
+        // Custom models should handle their own errors and return appropriate ScoredOutput
+        return [
+          [{ score: 0, output: undefined }]
+        ];
+      }
+    }
+
+    const errorModel = new ErrorModel();
+    
+    const result = await extract("Test text", {
+      languageModel: errorModel,
+      examples: mockExamples
+    });
+
+    expect(result).toBeDefined();
+    // Result should have empty extractions due to the error response
+    if ('extractions' in result) {
+      expect(result.extractions).toEqual([]);
+    }
+  });
+
+  it("should propagate unhandled custom model errors", async () => {
+    class UnhandledErrorModel implements BaseLanguageModel {
+      async infer(): Promise<ScoredOutput[][]> {
+        throw new Error("Unhandled custom model error");
+      }
+    }
+
+    const errorModel = new UnhandledErrorModel();
+    
+    // Unhandled errors should propagate up
+    await expect(extract("Test text", {
+      languageModel: errorModel,
+      examples: mockExamples
+    })).rejects.toThrow("Unhandled custom model error");
+  });
+
+  it("should work with custom model returning empty responses", async () => {
+    const customModel = new MockCustomLanguageModel([
+      JSON.stringify({ extractions: [] })
+    ]);
+
+    const result = await extract("Test text", {
+      languageModel: customModel,
+      examples: mockExamples
+    });
+
+    expect(result).toBeDefined();
+    if ('extractions' in result) {
+      expect(result.extractions).toEqual([]);
+    }
+  });
+
+  it("should prioritize custom model over modelType when both provided", async () => {
+    const customModel = new MockCustomLanguageModel([
+      JSON.stringify({
+        extractions: [
+          {
+            extractionClass: "custom",
+            extractionText: "from custom model"
+          }
+        ]
+      })
+    ]);
+
+    const result = await extract("Test text", {
+      languageModel: customModel,
+      modelType: "gemini", // This should be ignored
+      apiKey: "dummy-key", // This should be ignored
+      examples: mockExamples
+    });
+
+    expect(result).toBeDefined();
+    expect(customModel.getCallCount()).toBeGreaterThan(0);
+  });
+});

--- a/src/inference.ts
+++ b/src/inference.ts
@@ -33,7 +33,34 @@ export class InferenceOutputError extends Error {
   }
 }
 
+/**
+ * Base interface for language model implementations.
+ * Custom language models must implement this interface to be compatible with LangExtract.
+ * 
+ * @example
+ * // Custom language model implementation
+ * class MyCustomModel implements BaseLanguageModel {
+ *   async infer(batchPrompts: string[], options?: InferenceOptions): Promise<ScoredOutput[][]> {
+ *     const results: ScoredOutput[][] = [];
+ *     for (const prompt of batchPrompts) {
+ *       // Your custom inference logic here
+ *       const response = await myModelCall(prompt);
+ *       results.push([{ score: 1.0, output: response }]);
+ *     }
+ *     return results;
+ *   }
+ * }
+ */
 export interface BaseLanguageModel {
+  /**
+   * Perform inference on a batch of prompts.
+   * 
+   * @param batchPrompts - Array of prompt strings to process
+   * @param options - Optional inference parameters like temperature and maxDecodeSteps
+   * @returns Promise resolving to an array of arrays of ScoredOutput objects.
+   *          The outer array corresponds to each prompt, the inner array contains
+   *          one or more scored responses for that prompt.
+   */
   infer(batchPrompts: string[], options?: InferenceOptions): Promise<ScoredOutput[][]>;
 }
 


### PR DESCRIPTION
This adds support for passing in custom language models. We use our own wrappers for various language models for better monitoring so this would allow us to use them with langextract.